### PR TITLE
Fix Nomoregoogle link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
  **Redirects**: Automatically redirects the page to popular alternative.
 
  ## Thanks to
- ❤️ Special thanks to [@levelsio](https://twitter.com/levelsio). 🙅‍♀️ [Nomoregoogle](nomoregoogle.com) was an inspiration for this.
+ ❤️ Special thanks to [@levelsio](https://twitter.com/levelsio). 🙅‍♀️ [Nomoregoogle](https://nomoregoogle.com) was an inspiration for this.
 
  ## License
  MIT License


### PR DESCRIPTION
Hi,

I noticed the link to nomoregoogle.com was not working. It needed the full url to open correctly otherwise it went to https://github.com/sarthology/nomoogle/blob/master/nomoregoogle.com

