### PR TITLE
Add Google Play and Google News

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -513,5 +513,32 @@
                 "logoUrl": "https://logo.clearbit.com/www.quad9.net"
             }
         ]
+    },
+    {
+        "title": "Google Play Store",
+        "url": "https://play.google.com/store",
+        "alternatives": [
+            {
+                "name": "F-Droid",
+                "url": "https://f-droid.org/",
+                "logoUrl": "https://logo.clearbit.com/f-droid.org"
+            }
+        ]
+    },
+    {
+        "title": "Google News",
+        "url": "https://news.google.com",
+        "alternatives": [
+            {
+                "name": "Associated Press",
+                "url": "https://apnews.com/",
+                "logoUrl": "https://logo.clearbit.com/apnews.com"
+            },
+            {
+                "name": "Reuters",
+                "url": "https://www.reuters.com/",
+                "logoUrl": "https://logo.clearbit.com/reuters.com"
+            }
+        ]
     }
 ]


### PR DESCRIPTION
These seem like huge omissions here, particularly with the political context of News, in particular. I was considering alternative aggregators to news.google.com, but basically what comes to mind is Bing News. Since Bing was left off search alternatives, I wasn't sure it fit here.

AP and Reuters are two of the most universally recognized news organizations which are the source for a significant portion of stories elsewhere, and they update extremely frequently. Pretty much every "media bias chart" type entity recognizes them as incredibly neutral entities, and I figured they'd be a good choice rather than a potentially biased news aggregator.

The possible alternative here would be to recommend RSS feed tools such as Feedly, but I figured the "immediate click alternative" to something which would show news stories like news.google was the way to go.

I feel like most people go to the Play Store for Android apps, and so it's safe to assume that when we're pushing alternatives, that's what we're pushing. It *might* be prudent to look at what subdirectories of it people are on and refer to alternate video on demand, ebook, and music platforms are out there, but I am not sure if that can be done while still pushing the root play.google.com folks somewhere.

Side note: This PR is browser-edited after discovering your repo on GitHub, it has not been tested in any way.